### PR TITLE
Add support for configuring CPU temperature offset

### DIFF
--- a/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
+++ b/packages/bsp/common/etc/update-motd.d/30-armbian-sysinfo
@@ -21,6 +21,8 @@ PRIMARY_DIRECTION="rx"
 STORAGE=/dev/sda1
 SHOW_IP_PATTERN="^bond.*|^[ewr].*|^br.*|^lt.*|^umts.*|^lan.*"
 CPU_TEMP_LIMIT=60
+# Temperature offset in Celcius degrees
+CPU_TEMP_OFFSET=0
 HDD_TEMP_LIMIT=60
 AMB_TEMP_LIMIT=40
 
@@ -58,6 +60,8 @@ function getboardtemp() {
 		# fallback to PMIC temperature
 		board_temp=$(awk '{printf("%d",$1/1000)}' </etc/armbianmonitor/datasources/pmictemp)
 	fi
+	# Some boards, such as the Orange Pi Zero LTS, report shifted CPU temperatures
+	board_temp=$((board_temp + CPU_TEMP_OFFSET))
 } # getboardtemp
 
 function batteryinfo() {


### PR DESCRIPTION
Some boards, such as the Orange Pi Zero LTS, report shifted CPU temperatures.
For more details, see https://forum.armbian.com/topic/11534-orange-pi-zero-lts-incorrect-temps-reported/

------

It might be a good idea to fix it in the kernel itself, however I can't find the actual sources used by armbian and such an option might also be useful with other hardware.